### PR TITLE
#6 New Teletype Convention POC

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -9,10 +9,6 @@ Default text color
 and background color
 */
 
-.p {
-    line-height: 2em !important;
-}
-
 .md-header, .md-footer-nav {
     background-color: #252D34 !important;
 }

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -8,6 +8,11 @@
 Default text color
 and background color
 */
+
+.p {
+    line-height: 2em !important;
+}
+
 .md-header, .md-footer-nav {
     background-color: #252D34 !important;
 }

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -8,7 +8,6 @@
 Default text color
 and background color
 */
-
 .md-header, .md-footer-nav {
     background-color: #252D34 !important;
 }

--- a/docs/teletype.md
+++ b/docs/teletype.md
@@ -1,8 +1,99 @@
 # DETA Teletype Commands (Console)
 
+## Conventions
 User defined variable inputs are indicated between `<` and `>` symbols, as such: `<variable_name>`. 
 
 Specific examples of valid commands are indicated by `#`.
+
+Teletype commands on DETA programs follow the convention:
+
+`<action> <group_name>/<program_name> <[action specific args]>` 
+
+`<group_name>/<program_name>` can be shortcut to `<program_name>` if there is no conflict or to refer to a groupless program of `<program_name>`.
+
+`<group_name>/<program_name>` can be omitted if a program is open in the console and the action applies to said open program.
+
+## Program Commands
+
+### Listing Programs
+
+All programs in a space
+```shell
+ls
+```
+
+Filter by group
+```shell
+ls <group_name>
+
+# ls group_one
+
+ls --group <group_name>
+
+# ls --group group_one
+```
+
+
+### Creating a Program
+
+```shell
+new <program_name>
+
+# new prog_one
+
+new <program_name> --group <group_name>
+
+# new prog_one --group group_one
+```
+Names can contain letters, digits, `-` and `_`. No spaces or other characters are allowed.
+
+If the `--group` keyword is not specified, the program will be groupless.
+
+### Running Programs
+
+```shell
+run <group_name>/<program_name> --<kwarg_name1> <kwarg_value1> --<kwarg_name2> <kwarg_value2>
+
+# run <group_name>/<program_name> --name Beverly --age 99
+
+# run --name Beverly --age 99
+```
+
+After a program is opened the path can be dropped to run it as a shortcut.
+
+### Opening a Program
+
+```shell
+open <prog_name>
+
+# open prog_one
+
+open <group_name>/<program_name>
+
+# open <group_name>/<program_name>
+```
+
+### Changing the Group & Name of a Program
+
+```shell
+mv <program_name> <new_program_name>
+
+# mv prog_one prog_two
+
+mv <group_name>/<program_name> <new_group_name>/<new_program_name>
+
+# mv group_one/prog_two group_one/prog_two
+```
+
+To refer to the groupless case, the `<group_name>` should be `root`.
+
+```shell
+# mv group_one/prog_two root/prog_one
+
+# mv root/prog_one group_one/prog_one
+```
+
+Two programs of the same name cannot live in the same group.
 
 ## Space Commands
 
@@ -26,104 +117,94 @@ open -s <space_name>
 # open -s space_one
 ```
 
-## Program Commands
+## Commands for Program-Specific Objects
 
-### Listing Programs
-```shell
-ls
-
-ls --group <group_name>
-
-# ls --group group_one
-
-ls <group_name>
-
-# ls group_one
-```
-
-### Creating a Program
+Many objects are sub-resources belonging under DETA *programs*. The conventions for this case are either of:
 
 ```shell
-new <program_name>
+<action> <program_path> -<object_flag> <[flag specific args]>
 
-# new prog_one
-
-new <program_name> --group <group_name>
-
-# new prog_one --group group_one
-```
-Names can contain letters, digits, `-` and `_`. No spaces or other characters are allowed.
-
-If the `--group` keyword is not specified, the program will be groupless.
-
-### Opening a Program
-
-```shell
-open <prog_name>
-
-# open prog_one
-
-open <group_name>/<program_name>
-
-# open group_one/prog_one
-```
-The path convention `<group_name>`/`<program_name>` is required if there is a conflict and there is not a groupless program named `<program_name>`.
-
-### Changing the Group & Name of a Program
-
-```shell
-mv <program_name> <new_program_name>
-
-# mv prog_one prog_two
-
-mv <group_name>/<program_name> <new_group_name>/<new_program_name>
-
-# mv group_one/prog_two group_one/prog_two
-```
-Two programs of the same name cannot live in the same group.
-
-The path convention `<group_name>`/`<program_name>` is required if there is a conflict and there is not a groupless program named `<program_name>`.
-
-To refer to the groupless case, the `<group_name>` should be `root`.
-
-```shell
-# mv group_one/prog_two root/prog_one
-
-# mv root/prog_one group_one/prog_one
+<action> -<object_flag> <program_path> <[flag specific args]>
 ```
 
-### Scheduling Program Execution
+When a program is open in the console, the path can be dropped as a shortcut.
+
+### Execution Schedules
 
 DETA's scheduler accepts cron expressions of length 6, with times in UTC.
 
+#### Setting:
 ```shell
-cron <group_name>/<prog_name> <minute> <hour> <month_day> <week_day> <year>
+set <group_name>/<prog_name> -cron <minute> <hour> <month_day> <week_day> <year>
 
-# cron group_one/prog_one 0 10 * * ? *
+# set group_one/prog_one -cron 0 10 * * ? *
 ```
 
-Rate based scheduling is also accepted.
+Rate based scheduling is also accepted:
 
 ```shell
-cron <group_name>/<prog_name> <interval> <unit>
+set <group_name>/<prog_name> -cron <interval> <unit>
 
-# cron group_one/prog_one 3 minutes
+# set group_one/prog_one -cron 3 minutes
 ```
 
-Rate based scheduling will execute a program every `interval` according to the `unit`. Accepted `unit` values are `minutes`, `hours`, `days`. If the `interval` is `1`, the singular of `minute`, `hour`, or `day` should be used.
+Rate based scheduling will execute a program every `interval` according to the `unit`. 
 
-### Removing an Execution Schedule for a Program
+Accepted `unit` values are `minutes`, `hours`, `days`. 
 
-The execution schedule for a program can be removed with the `-r` flag.
+If the `interval` is `1`, the singular of `minute`, `hour`, or `day` should be used.
+
+#### Removing:
 
 ```shell
-cron -r <group_name>/<prog_name>
 
-# cron -r group_one/prog_one
+rm <group_name>/<prog_name> -cron 
+
+# rm group_one/prog_one -cron 
 ```
 
+The program path can be dropped to set or remove schedules for open programs.
+
+### APIs
+
+#### Public
+
+```shell
+set <group_name>/<prog_name> -api public
+
+# set group_one/prog_one -api public
+```
+
+#### Private (default setting)
+
+```shell
+set <group_name>/<prog_name> -api private
+
+# set group_one/prog_one -api private
+```
+
+The program path can be dropped for open programs to make it's API public or private.
+
+### Program Specific Permissions
+
+```shell
+set <group_name>/<prog_name> -perms --username_one '<[perms]>' --username_two '<[perms]>'
+
+# set group_one/prog_one -perms --beverly 'edit, run' --wesley 'run'
+
+# set -perms DETA -all
+```
+As a *Space admin* or creator of a program, you can set user level permissions of a program.
+
+Accepted permissions are `edit`, `run`, and `full`.
+
+Permissions should be encapsulated in single quotes and comma separated.
+
+The program path can be dropped for open programs.
 
 ## Commands Valid After a Program is Open
+
+Files, packages, environment variables, and the DETA lib version can only be manipulated in the console in the context of an open program.
 
 ### Creating Files
 
@@ -146,13 +227,11 @@ edit <file_name>
 ```
 
 
-### Mass Deploy
+### Mass Deploy (all changed files)
 
 ```shell
 deploy
 ```
-
-Deploys all changes you have made to your files.
 
 ### Selected Deploy
 
@@ -164,7 +243,7 @@ deploy <file_name_one> <file_name_two>
 
 Multiple file deploys are accepted, conditional on space separation.
 
-### Removing files
+### Removing Files
 
 ```shell
 rm <file_name_one> <file_name_two>
@@ -180,33 +259,6 @@ Multiple file removals are accepted, conditional on space separation.
 mv -fl <old_path_name> <new_path_name>
 
 # mv file.py calculator.py
-```
-
-### Environment Variables
-
-#### Creation
-
-```shell
-env set --<env_var_name> <env_var_val> --<env_var_name2> <env_var_value2>
-
-# env set --my_api_key X2019WzT
-```
-
-#### Deletion
-
-```shell
-env rm <env_var_name> <env_var_name2> 
-
-# env rm my_api_key
-```
-Environment variable names must start with a letter and can contain letters, digits and `_`. No spaces or other characters are allowed.
-
-### Running Programs
-
-```shell
-run --<kwarg_name1> <kwarg_value1> --<kwarg_name2> <kwarg_value2>
-
-# run --name Beverly --age 99
 ```
 
 ### Package Installation
@@ -237,45 +289,38 @@ pip clean
 
 All packages can be removed with the clean command.
 
-### Execution Schedules
+### Environment Variables
 
-An execution schedule can be set or removed for an open program, no path is necessary. Rate based expressions are also accepted.
+#### Setting:
 
 ```shell
-cron <minute> <hour> <month_day> <week_day> <year>
-cron <interval> <unit>
+set -env --<env_var_name> <env_var_val> --<env_var_name2> <env_var_value2>
 
-# cron 0/5 8-17 ? * MON-FRI *
-# cron 2 minutes
+# set -env --my_api_key X2019WzT
 ```
 
-The `-r` flag can also be used on an open program to remove an execution schedule.
+#### Removing:
 
 ```shell
+rm -env <env_var_name> <env_var_name2> 
 
-cron -r
+# rm -env my_api_key
+```
+Environment variable names must start with a letter and can contain letters, digits and `_`. No spaces or other characters are allowed.
+
+
+### Changing a Program's DETA Library Version
+
+```shell
+set -lib <lib_version>
+
+# set -lib 10
 ```
 
 ### Program Specific Information
 
 ```shell
 meta
-```
-
-### Vim Keybindings
-
-```shell
-vim
-```
-
-Vim keybindings can be added to the editor.
-
-### Changing a Program's DETA Library Version
-
-```shell
-lib use <lib_version>
-
-# lib use 4
 ```
 
 ### Closing a Program
@@ -285,6 +330,20 @@ close
 ```
 
 ## Other Commands
+
+### Keybindings
+
+```shell
+set -bindings vim
+
+set -bindings emacs
+```
+
+Vim and emacs keybindings can be added to and removed from the editor.
+
+```shell
+rm -bindings
+```
 
 ### Logout
 
@@ -298,6 +357,8 @@ logout
 ```shell
 help
 ```
+
+
 
 
 ## Feedback


### PR DESCRIPTION
Here is a POC for standardizing the Teletype.

The new convention is:

`<action> <group_name>/<program_name> <[action specific args]>` 

The path can be dropped for open programs in the console.

Many of the current & new 'actions' become flags for broader 'set' and 'rm' actions (env, lib, keybindings, api, permissions, cron).

This standard is not yet perfect but is arguably an improvement in that:
1. Standardizes the syntax to something like 'verb noun' (with location specifying to whom the noun belongs if the noun is not a program), whereas currently there is a mix of 'verb noun' and 'noun verb'.
2. Limits the growth of base level commands by turning them into flags for 'set' and 'rm'. Instead of every new resource having a base level command and then both 'set' and 'rm' args, these are generalized up one level. This will reduce the amount of code and can limit mental overhead for the user.
3. Lets many of the commands easily carry over to the Dash Teletype if needed for rapid modification and running of programs on the fly. (i.e. setting env vars, lib version, public api).

Once we work this out I can quickly modify the front end code.
